### PR TITLE
Add filter on subscribe

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -185,9 +185,9 @@ class MyPoliciesPlugin {
 
     // iterate through results and keep only documents which author is the current user
     const hits = [];
-    
+
     for (const hit of request.result.hits) {
-      if (hit.found && hit._meta.author === request.context.user._id) {
+      if (hit.found && hit._source._kuzzle_info.author === request.context.user._id) {
         hits.push(hit);
       } else {
         hits.push({

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,8 +19,8 @@ class MyPoliciesPlugin {
       'document:beforeDelete': 'assertCanUpdate',
       'document:beforeDeleteByQuery': 'addQueryFilter',
       'document:afterGet': 'assertCanRead',
-      'document:afterMGet': 'filterMgetResult'
-//      'realtime:beforeSubscribe': 'addSubscriptionFilter'
+      'document:afterMGet': 'filterMgetResult',
+      'realtime:beforeSubscribe': 'addSubscriptionFilter'
     };
   }
 
@@ -52,7 +52,7 @@ class MyPoliciesPlugin {
     // Add a filter on the document author
     const subscriptionFilter = {
       and: [
-        { equals: { "_kuzzle_info.author": request.context.user._id } }
+        { equals: { '_kuzzle_info.author': request.context.user._id } }
       ]
     };
 
@@ -139,9 +139,10 @@ class MyPoliciesPlugin {
         }
       };
 
-    if (request.input.body) {
+    if (! request.input.body) {
       request.input.body = {};
     }
+
     if (request.input.body.query) {
       queryObject.bool.must = request.input.body.query;
     }
@@ -167,6 +168,7 @@ class MyPoliciesPlugin {
     if (request.result._source._kuzzle_info.author !== request.context.user._id) {
       return this._denyRequest(request, callback);
     }
+
     callback(null, request);
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,8 @@ class MyPoliciesPlugin {
       'document:beforeDelete': 'assertCanUpdate',
       'document:beforeDeleteByQuery': 'addQueryFilter',
       'document:afterGet': 'assertCanRead',
-      'document:afterMGet': 'filterMgetResult'
+      'document:afterMGet': 'filterMgetResult',/*,
+      'realtime:beforeSubscribe': 'addSubscriptionFilter' */
     };
   }
 
@@ -33,6 +34,37 @@ class MyPoliciesPlugin {
   init (customConfig, context) {
     this.config = Object.assign(this.config, customConfig);
     this.context = context;
+  }
+
+  /**
+   * Inject an additional filter to subscribe requests:
+   *
+   * @param {Request} request The request that triggered the event
+   * @param {Function} callback The callback that bears the result of the
+   *                            function. Signature: `callback(error, request)`
+   */
+  addSubscriptionFilter (request, callback) {
+    // Do not filter results for admin users
+    if (request.context.user.profileIds.indexOf('admin') !== -1) {
+      return callback(null, request);
+    }
+
+    // Add a filter on the document author
+    const subscriptionFilter = {
+      and: [
+        { equals: { "_kuzzle_info.author": request.context.user._id } }
+      ]
+    };
+
+    // If there is an existent filter, add it to our filter
+    if (Object.keys(request.input.body).length > 0) {
+      subscriptionFilter.and.push(Object.values(request.input.body)[0]);
+    }
+
+    // Replace the subscription filter
+    request.input.body = subscriptionFilter;
+
+    callback(null, request);
   }
 
   /**
@@ -62,7 +94,7 @@ class MyPoliciesPlugin {
     this.context.accessors.execute(getRequest)
       .then(res => {
         // Deny the request if current user is not the author of the document
-        if (res.result._meta.author !== request.context.user._id) {
+        if (res.result._source._kuzzle_info.author !== request.context.user._id) {
           return this._denyRequest(request, callback);
         }
         callback(null, request);
@@ -132,7 +164,7 @@ class MyPoliciesPlugin {
     }
 
     // Deny the request if current user is not the author of the document
-    if (request.result._meta.author !== request.context.user._id) {
+    if (request.result._source._kuzzle_info.author !== request.context.user._id) {
       return this._denyRequest(request, callback);
     }
     callback(null, request);
@@ -151,21 +183,8 @@ class MyPoliciesPlugin {
       return callback(null, request);
     }
 
-    // iterate through results and keep only documents which author is the current user
-    const hits = [];
-    for (const hit of request.result.hits) {
-      if (hit.found && hit._meta.author === request.context.user._id) {
-        hits.push(hit);
-      } else {
-        hits.push({
-          _index: hit._index,
-          _type: hit._type,
-          _id: hit._id,
-          found: false
-        });
-      }
-    }
-    request.result.hits = hits;
+    request.result.hits = request.result.hits.filter(hit => hit._source._kuzzle_info.author === request.context.user._id);
+
     callback(null, request);
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,8 +19,8 @@ class MyPoliciesPlugin {
       'document:beforeDelete': 'assertCanUpdate',
       'document:beforeDeleteByQuery': 'addQueryFilter',
       'document:afterGet': 'assertCanRead',
-      'document:afterMGet': 'filterMgetResult',/*,
-      'realtime:beforeSubscribe': 'addSubscriptionFilter' */
+      'document:afterMGet': 'filterMgetResult'
+//      'realtime:beforeSubscribe': 'addSubscriptionFilter'
     };
   }
 
@@ -183,8 +183,23 @@ class MyPoliciesPlugin {
       return callback(null, request);
     }
 
-    request.result.hits = request.result.hits.filter(hit => hit._source._kuzzle_info.author === request.context.user._id);
+    // iterate through results and keep only documents which author is the current user
+    const hits = [];
+    
+    for (const hit of request.result.hits) {
+      if (hit.found && hit._meta.author === request.context.user._id) {
+        hits.push(hit);
+      } else {
+        hits.push({
+          _index: hit._index,
+          _type: hit._type,
+          _id: hit._id,
+          found: false
+        });
+      }
+    }
 
+    request.result.hits = hits;
     callback(null, request);
   }
 

--- a/package.json
+++ b/package.json
@@ -19,8 +19,6 @@
     "url": "https://github.com/kuzzleio/kuzzle-plugin-sample-custom-policies/issues"
   },
   "homepage": "https://github.com/kuzzleio/kuzzle-plugin-sample-custom-policies#readme",
-  "devDependencies": {
-  },
-  "dependencies": {
-  }
+  "devDependencies": {},
+  "dependencies": {}
 }


### PR DESCRIPTION
## What does this PR do ?

:warning: Won't work before https://github.com/kuzzleio/kuzzle/pull/1185 gets merged :warning: 

This PR add a filter on the `realtime:subscribe` action.  
In this way, a user can only receive notifications about document he own.  

### How should this be manually tested?

  - Step 1: Create 2 users in the Admin Console
  - Step 2: Create an index and a collection
  - Step 3: Subscribe to the collection with user1
  - Step 4: Create a document with user2, you shouldn't see a notification
  - Step 5: Create a document with user2, you should see a notification

### Other changes

  - Use `_kuzzle_info` field instead of `meta`